### PR TITLE
Fix android issue when open dialog after use sdk

### DIFF
--- a/android/src/main/kotlin/com/example/idenfy_sdk_flutter/IdenfySdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/example/idenfy_sdk_flutter/IdenfySdkFlutterPlugin.kt
@@ -45,7 +45,7 @@ class IdenfySdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, P
 
       IdenfyController.getInstance().initializeIdenfySDKV2WithManual(this.activity, IdenfyController.IDENFY_REQUEST_CODE, idenfySettingsV2)
     } else {
-      result.notImplemented()
+      //result.notImplemented()
     }
   }
 
@@ -77,7 +77,7 @@ class IdenfySdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, P
         }
       }
     } else {
-      mResult?.notImplemented()
+      //mResult?.notImplemented()
     }
     return true
   }


### PR DESCRIPTION
When open dialog after use sdk
ERROR:
com.kogopay.kogopay.MainActivity}: java.lang.IllegalStateException: Reply already submitted
E/AndroidRuntime(11049):  at android.app.ActivityThread.deliverResults(ActivityThread.java:5163)
E/AndroidRuntime(11049):  at android.app.ActivityThread.handleSendResult(ActivityThread.java:5204)
E/AndroidRuntime(11049):  at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
E/AndroidRuntime(11049):  at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
E/AndroidRuntime(11049):  at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
E/AndroidRuntime(11049):  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2135)
E/AndroidRuntime(11049):  at android.os.Handler.dispatchMessage(Handler.java:106)
E/AndroidRuntime(11049):  at android.os.Looper.loop(Looper.java:236)
E/AndroidRuntime(11049):  at android.app.ActivityThread.main(ActivityThread.java:8057)
E/AndroidRuntime(11049):  at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(11049):  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
E/AndroidRuntime(11049):  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
E/AndroidRuntime(11049): Caused by: java.lang.IllegalStateException: Reply already submitted
E/AndroidRuntime(11049):  at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:155)
E/AndroidRuntime(11049):  at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.notImplemented(MethodChannel.java:248)
E/AndroidRuntime(11049):  at com.example.idenfy_sdk_flutter.IdenfySdkFlutterPlugin.onActivityResult(IdenfySdkFlutterPlugin.kt:80)
E/AndroidRuntime(11049):  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEngineConnectionRegistry.java:739)
E/AndroidRuntime(11049):  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.onActivityResult(FlutterEngineConnectionRegistry.java:426)
E/AndroidRuntime(11049):  at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onActivityResult(FlutterActivityAndFragmentDelegate.java:677)
E/AndroidRuntime(11049):  at io.flutter.embedding.android.FlutterActivity.onActivityResult(FlutterActivity.java:624)
E/AndroidRuntime(11049):  at android.app.Activity.dispatchActivityResult(Activity.java:8508)
E/AndroidRuntime(11049):  at android.app.ActivityThread.deliverResults(ActivityThread.java:5156)
E/AndroidRuntime(11049):  ... 11 more
I/Sentry  (11049): Not possible to read external files directory
I/Process (11049): Sending signal. PID: 11049 SIG: 9